### PR TITLE
Add basic quaternion based attitude estimation API

### DIFF
--- a/app/src/CMakeLists.txt
+++ b/app/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(app PRIVATE
     imu_zephyr_sensor.c
     main.c
+    quaternion_cmsis.c
 )

--- a/app/src/attitude.c
+++ b/app/src/attitude.c
@@ -1,0 +1,53 @@
+#include <math.h> /** TODO: Consider using cmsis fastmath */
+#include "attitude.h"
+#include "quaternion.h"
+
+/** See: https://folk.ntnu.no/skoge/prost/proceedings/ecc-2013/data/papers/0927.pdf
+  * Access 24.04.2023
+  *
+  * For more useful info about converting quaternion to euler see:
+  * http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/index.htm
+  *
+  * TODO: Handle singularities.
+  * TODO: cmsis fastmath could probably be used insted of math.h
+  */
+void attitude_quaternion_to_euler(float q[4], float ang[3]) {
+    float tmp_1, tmp_2;
+    float sqw = q[0] * q[0];
+    float sqx = q[1] * q[1];
+    float sqy = q[2] * q[2];
+    float sqz = q[3] * q[3];
+    // roll
+    tmp_1 = 2.0f * (q[0] * q[1] + q[2] * q[3]);
+    tmp_2 = sqw - sqx - sqy + sqz;
+    ang[1] = atan2f(tmp_1, tmp_2);
+    // pitch
+    tmp_1 = 2.0f * (q[0] * q[2] - q[3] * q[1]);
+    ang[0] = asin(tmp_1);
+    // yaw
+    tmp_1 = 2.0f * (q[0] * q[3] + q[1] * q[2]);
+    tmp_2 = sqw + sqx - sqy - sqz;
+    ang[2] = atan2f(tmp_1, tmp_2);
+};
+
+static void integrate_quaternion(float q_att[4], float q_dt[4], int dt) {
+    for (int i = 0; i < 4; i++) {
+        q_att[i] += q_dt[i] * (dt / 1000.0f);
+    }
+}
+
+void attitude_get_quaternion(float q_att[4], float ang_v[3], int dt) {
+    float q_dt[4] = {1.0f, 0.0f, 0.0f, 0.0f};
+    float q_v[4] = {0.0f, ang_v[0], ang_v[1], ang_v[2]};
+
+    quaternion_product(q_att, q_v, q_dt);
+    for (int i = 0; i < 4; i++) {
+        q_dt[i] *= 0.5f;
+    }
+    /**
+     * TODO: Don't run operations in-place?
+     */
+    quaternion_normalize(q_dt, q_dt);
+    integrate_quaternion(q_att, q_dt, dt);
+    quaternion_normalize(q_att, q_att);
+}

--- a/app/src/attitude.h
+++ b/app/src/attitude.h
@@ -1,0 +1,8 @@
+#ifndef __SRC_ATTITUDE_H__
+#define __SRC_ATTITUDE_H__
+
+void attitude_quaternion_to_euler(float q[4], float ang[3]);
+void attitude_get_quaternion(float q_att[4], float ang_v[3], int dt);
+void attitude_get_euler(float ang[3], float ang_v[3], int dt);
+
+#endif  // __SRC_ATTITUDE_H__

--- a/app/src/quaternion.h
+++ b/app/src/quaternion.h
@@ -1,0 +1,7 @@
+#ifndef __QUATERNION_H__
+#define __QUATERNION_H__
+
+void quaternion_product(float *qa, float *qb, float *out);
+void quaternion_normalize(float *qa, float *out);
+
+#endif  // __QUATERNION_H__

--- a/app/src/quaternion_cmsis.c
+++ b/app/src/quaternion_cmsis.c
@@ -1,0 +1,10 @@
+#include <arm_math.h>
+#include "quaternion.h"
+
+void quaternion_product(float *qa, float *qb, float *out) {
+    return arm_quaternion_product_single_f32(qa, qb, out);
+}
+
+void quaternion_normalize(float *qa, float *out) {
+    return arm_quaternion_normalize_f32(qa, out, 1);
+}

--- a/project.yml
+++ b/project.yml
@@ -85,7 +85,8 @@
   :placement: :end
   :flag: "-l${1}"
   :path_flag: "-L ${1}"
-  :system: []    # for example, you might list 'm' to grab the math library
+  :system: # for example, you might list 'm' to grab the math library
+    - m # math.h
   :test: []
   :release: []
 

--- a/test/unit/test_attitude.c
+++ b/test/unit/test_attitude.c
@@ -1,0 +1,38 @@
+#include <unity.h>
+#include "attitude.h"
+#include "mock_quaternion.h"
+
+void test_quaternion_to_euler_returns_all_zero_angles_when_quaternion_is_unit() {
+    float test_quaternion[4] = {1, 0, 0, 0};
+    float expected_angles[3] = {0, 0, 0};
+    float test_angles[3] = {0,};
+    attitude_quaternion_to_euler(test_quaternion, test_angles);
+    TEST_ASSERT_EQUAL_FLOAT_ARRAY(expected_angles, test_angles, 3);
+}
+
+void test_quaternion_to_euler_expected_pitch_between_0_and_90() {
+    float test_quaternion[4] = {0.92, 0, 0.39, 0};
+    float test_angles[3] = {0,};
+    attitude_quaternion_to_euler(test_quaternion, test_angles);
+    TEST_ASSERT_EQUAL_FLOAT(0, test_angles[1]);
+    TEST_ASSERT_EQUAL_FLOAT(0, test_angles[2]);
+    TEST_ASSERT_FLOAT_WITHIN(0.1, 0.8, test_angles[0]);
+}
+
+void test_quaternion_to_euler_expected_roll_between_0_and_90() {
+    float test_quaternion[4] = {0.92, 0.39, 0, 0};
+    float test_angles[3] = {0,};
+    attitude_quaternion_to_euler(test_quaternion, test_angles);
+    TEST_ASSERT_EQUAL_FLOAT(0, test_angles[0]);
+    TEST_ASSERT_EQUAL_FLOAT(0, test_angles[2]);
+    TEST_ASSERT_FLOAT_WITHIN(0.1, 0.8, test_angles[1]);
+}
+
+void test_quaternion_to_euler_expected_yaw_between_0_and_90() {
+    float test_quaternion[4] = {0.92, 0, 0, 0.39};
+    float test_angles[3] = {0,};
+    attitude_quaternion_to_euler(test_quaternion, test_angles);
+    TEST_ASSERT_EQUAL_FLOAT(0, test_angles[0]);
+    TEST_ASSERT_EQUAL_FLOAT(0, test_angles[1]);
+    TEST_ASSERT_FLOAT_WITHIN(0.1, 0.8, test_angles[2]);
+}


### PR DESCRIPTION
Add attitude estimation functions. Attitude info will be represented in quaternion form. attitude_get_quaterion() integrates angular velocity vector into a quaternion form.
Function to convert quaternion to euler angles is also provided. Add really basic unit tests for now.

This implementation is still rough and incomplete and definitely needs refinement, but this is a good basis to have some data to put feed into the future controller loop.