### PR TITLE
input: Update to use new LL API and SBus

### DIFF
--- a/controller/app/include/controller/input.h
+++ b/controller/app/include/controller/input.h
@@ -41,4 +41,11 @@ bool input_set_calibration(
 
 float input_get_channel_value(enum input_channel ch);
 
+/** Initialize input system. */
+bool input_init(void);
+/** Start receiving input data. */
+bool input_start(void);
+/** Stop receiving input data. */
+bool input_stop(void);
+
 #endif  // __INPUT_H__

--- a/controller/app/include/controller/low_level/input_ll.h
+++ b/controller/app/include/controller/low_level/input_ll.h
@@ -4,14 +4,13 @@
 #include <stdint.h>
 
 /** Callback that will be called upon reception of a full frame (all channels). */
-typedef void (*input_ll_frame_callback)(uint8_t *data, uint8_t size);
+typedef void (*input_ll_frame_callback)(uint16_t *data, uint8_t size);
 /** Callback that will be called upon reception of a data on a specified channel. */
-typedef void (*input_ll_channel_callback)(uint8_t channel, uint8_t *data, uint8_t size);
+typedef void (*input_ll_channel_callback)(uint8_t channel, uint16_t *data, uint8_t size);
 
 struct input_ll_api {
     int (*set_frame_callback)(input_ll_frame_callback cb);
     int (*set_channel_callback)(input_ll_channel_callback cb);
-    int (*read_channel_raw)(uint8_t channel, uint16_t *data, uint8_t *status);
     int (*start)(void);
     int (*stop)(void);
 };

--- a/controller/app/include/controller/sbus_decoder.h
+++ b/controller/app/include/controller/sbus_decoder.h
@@ -5,14 +5,17 @@
 #include <stdbool.h>
 
 /** Number of regular SBus channels (excluding binary channel 16 and 17). */
-#define SBUS_CHANNELS   16
-#define SBUS_FRAME_SIZE 25
-#define SBUS_HEADER     0x0F
-#define SBUS_FOOTER     0x00
+#define SBUS_DATA_CHANNELS 16
+/** Total number of SBus channels (including binary channels). */
+#define SBUS_TOT_CHANNELS  SBUS_DATA_CHANNELS + 2
+#define SBUS_FRAME_SIZE    25
+
+#define SBUS_HEADER       0x0F
+#define SBUS_FOOTER       0x00
 
 /** SBus frame data structure. */
 struct sbus_frame {
-    uint16_t channels[SBUS_CHANNELS];
+    uint16_t channels[SBUS_DATA_CHANNELS];
     bool ch17;
     bool ch18;
     bool frame_lost;

--- a/controller/app/src/platform/input_shell.c
+++ b/controller/app/src/platform/input_shell.c
@@ -51,7 +51,22 @@ static int cmd_input_read(const struct shell *sh, size_t argc, char **argv)
     return 0;
 }
 
+static int cmd_start(const struct shell *sh, size_t argc, char **argv)
+{
+    input_init();
+    input_start();
+    return 0;
+}
+
+static int cmd_stop(const struct shell *sh, size_t argc, char **argv)
+{
+    input_stop();
+    return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(input_sub_cmds,
+    SHELL_CMD(start, NULL, "start", cmd_start),
+    SHELL_CMD(stop, NULL, "stop", cmd_stop),
     SHELL_CMD_ARG(configure, NULL, "configure <channel> <pwm_ch> <value_min> <value_max>", cmd_input_configure, 5, 0),
     SHELL_CMD_ARG(read, NULL, "read <channel>", cmd_input_read, 2, 0),
     SHELL_CMD_ARG(read_raw, NULL, "read_raw <channel>", cmd_input_read_raw, 2, 0),


### PR DESCRIPTION
Update input system to use new LL API.
Use callback mechanism for capturing frames
from low level implementation.
For now provide single, SBus implementation.
Add necessary adaptations of all subsystems.